### PR TITLE
fix(setup): set an empty string to endpointUrl for EKS

### DIFF
--- a/content/en/docs/setup/install/single_cluster_eks.md
+++ b/content/en/docs/setup/install/single_cluster_eks.md
@@ -400,6 +400,7 @@ global:
     s3:
       bucket: "${S3_BUCKET_NAME}"
       region: "${S3_REGION}"
+      endpointUrl: ""
 
 prepare:
   database:


### PR DESCRIPTION
We can remove once we release the latest charts.