### PR TITLE
docs: add integration for AI Shell

### DIFF
--- a/content/en/docs/integration/ai_shell.md
+++ b/content/en/docs/integration/ai_shell.md
@@ -1,0 +1,20 @@
+---
+title: AI Shell
+description: Integrate with AI Shell to power your shell with the AI assistant.
+weight: 6
+---
+
+[AI Shell](https://github.com/BuilderIO/ai-shell) is an open source tool that converts natural language to shell commands.
+
+```bash
+npm install -g @builder.io/ai-shell
+ai config set OPENAI_API_ENDPOINT=<Base URL (e.g., http://localhost:8080/v1)>"
+ai config set OPENAI_KEY=<API key>
+ai config set MODEL=<model name>
+```
+
+Then you can run the `ai` command and ask what you want in plain English and generate a shell command with a human readable explanation of it.
+
+```bash
+ai what is my ip address
+```

--- a/content/en/docs/integration/slackbot.md
+++ b/content/en/docs/integration/slackbot.md
@@ -1,7 +1,7 @@
 ---
 title: Slackbot
 description: Build a Slackbot that integrates with LLMariner
-weight: 6
+weight: 7
 ---
 
 You can build a Slackbot that is integrated with LLMariner. The bot can provide a chat UI with Slack


### PR DESCRIPTION
We don't necessarily need to list all open source projects that have the OpenAI integration, but it's nice to have more in the list.