### PR TITLE
docs(integration): change the order of integration tools

### DIFF
--- a/content/en/docs/integration/ai_shell.md
+++ b/content/en/docs/integration/ai_shell.md
@@ -1,7 +1,7 @@
 ---
 title: AI Shell
 description: Integrate with AI Shell to power your shell with the AI assistant.
-weight: 6
+weight: 3
 ---
 
 [AI Shell](https://github.com/BuilderIO/ai-shell) is an open source tool that converts natural language to shell commands.

--- a/content/en/docs/integration/k8sgpt.md
+++ b/content/en/docs/integration/k8sgpt.md
@@ -1,7 +1,7 @@
 ---
 title: k8sgpt
 description: Integrate with k8sgpt to diagnose and triage issues in your Kubernetes clusters.
-weight: 6
+weight: 4
 ---
 
 [k8sgpt](https://github.com/k8sgpt-ai/k8sgpt) is a tool for scanning your

--- a/content/en/docs/integration/langfuse.md
+++ b/content/en/docs/integration/langfuse.md
@@ -1,7 +1,7 @@
 ---
 title: Langfuse
 description: Integrate with Langfuse for LLM engineering.
-weight: 5
+weight: 7
 ---
 
 [Langfuse](https://github.com/langfuse/langfuse) is an open source LLM engineering platform. You can integrate Langfuse

--- a/content/en/docs/integration/mlflow.md
+++ b/content/en/docs/integration/mlflow.md
@@ -1,7 +1,7 @@
 ---
 title: MLflow
 description: Integrate with MLflow.
-weight: 3
+weight: 6
 ---
 
 [MLflow](https://mlflow.org/) is an open-source tool for managing the machine learning lifecycle. It has various features for LLMs ([link](https://mlflow.org/docs/latest/llms/index.html)) and integration with OpenAI. We can apply these MLflow features to the LLM endpoints provided by LLMariner.

--- a/content/en/docs/integration/slackbot.md
+++ b/content/en/docs/integration/slackbot.md
@@ -1,7 +1,7 @@
 ---
 title: Slackbot
 description: Build a Slackbot that integrates with LLMariner
-weight: 7
+weight: 5
 ---
 
 You can build a Slackbot that is integrated with LLMariner. The bot can provide a chat UI with Slack

--- a/content/en/docs/integration/wandb.md
+++ b/content/en/docs/integration/wandb.md
@@ -2,7 +2,7 @@
 title: Weights & Biases (W&B)
 linkTitle: Weights & Biases
 description: Integration with W&B and see the progress of your fine-tuning jobs.
-weight: 4
+weight: 8
 ---
 
 [Weights and Biases (W&B)](https://wandb.ai/) is an AI developer platform. LLMariner provides the integration with W&B so that metrics for fine-tuning jobs are reported to W&B. With the integration, you can easily see the progress of your fine-tuning jobs, such as training epoch, loss, etc.


### PR DESCRIPTION
Change the order so that tools for dev(ops) come first. MLOps tools come after that.