### PR TITLE
docs(integration): add a page for Aider

### DIFF
--- a/content/en/docs/integration/ai_shell.md
+++ b/content/en/docs/integration/ai_shell.md
@@ -1,7 +1,7 @@
 ---
 title: AI Shell
 description: Integrate with AI Shell to power your shell with the AI assistant.
-weight: 3
+weight: 4
 ---
 
 [AI Shell](https://github.com/BuilderIO/ai-shell) is an open source tool that converts natural language to shell commands.

--- a/content/en/docs/integration/aider.md
+++ b/content/en/docs/integration/aider.md
@@ -1,0 +1,34 @@
+---
+title: Aider
+description: Integrate with Aider for AI pair programming
+weight: 3
+---
+
+[Aider](https://aider.chat/) is AI pair programming in your terminal or browser.
+
+Aider supports the OpenAI compatible API, and you can configure the endpoint
+and the API key with environment variables.
+
+
+Here is an example installation and configuration procedure.
+
+```bash
+python -m pip install -U aider-chat
+
+export OPENAI_API_BASE=<Base URL (e.g., http://localhost:8080/v1)>
+export OPENAI_API_KEY=<API key>
+```
+
+You can then run Aider in your terminal or browser. Here is an example command
+that launches Aider in your browser with Llama 3.1 70B.
+
+```bash
+<Move to your github repo directory>
+
+aider --model openai/meta-llama-Meta-Llama-3.1-70B-Instruct-awq --browser
+```
+
+Please note that the model name requires the `openai/` prefix.
+
+https://aider.chat/examples/README.html has example chat transcripts
+for building applications (e.g., "make a flask app with a /hello endpoint that returns hello world").

--- a/content/en/docs/integration/k8sgpt.md
+++ b/content/en/docs/integration/k8sgpt.md
@@ -1,7 +1,7 @@
 ---
 title: k8sgpt
 description: Integrate with k8sgpt to diagnose and triage issues in your Kubernetes clusters.
-weight: 4
+weight: 5
 ---
 
 [k8sgpt](https://github.com/k8sgpt-ai/k8sgpt) is a tool for scanning your

--- a/content/en/docs/integration/langfuse.md
+++ b/content/en/docs/integration/langfuse.md
@@ -1,7 +1,7 @@
 ---
 title: Langfuse
 description: Integrate with Langfuse for LLM engineering.
-weight: 7
+weight: 8
 ---
 
 [Langfuse](https://github.com/langfuse/langfuse) is an open source LLM engineering platform. You can integrate Langfuse

--- a/content/en/docs/integration/mlflow.md
+++ b/content/en/docs/integration/mlflow.md
@@ -1,7 +1,7 @@
 ---
 title: MLflow
 description: Integrate with MLflow.
-weight: 6
+weight: 7
 ---
 
 [MLflow](https://mlflow.org/) is an open-source tool for managing the machine learning lifecycle. It has various features for LLMs ([link](https://mlflow.org/docs/latest/llms/index.html)) and integration with OpenAI. We can apply these MLflow features to the LLM endpoints provided by LLMariner.

--- a/content/en/docs/integration/slackbot.md
+++ b/content/en/docs/integration/slackbot.md
@@ -1,7 +1,7 @@
 ---
 title: Slackbot
 description: Build a Slackbot that integrates with LLMariner
-weight: 5
+weight: 6
 ---
 
 You can build a Slackbot that is integrated with LLMariner. The bot can provide a chat UI with Slack

--- a/content/en/docs/integration/wandb.md
+++ b/content/en/docs/integration/wandb.md
@@ -2,7 +2,7 @@
 title: Weights & Biases (W&B)
 linkTitle: Weights & Biases
 description: Integration with W&B and see the progress of your fine-tuning jobs.
-weight: 8
+weight: 9
 ---
 
 [Weights and Biases (W&B)](https://wandb.ai/) is an AI developer platform. LLMariner provides the integration with W&B so that metrics for fine-tuning jobs are reported to W&B. With the integration, you can easily see the progress of your fine-tuning jobs, such as training epoch, loss, etc.


### PR DESCRIPTION
Mostly working, but we see `assistant<|end_header_id|>` at the beginning of the message due to some templating related issue.


