### PR TITLE
docs: create a subsection for "CLI installation"

### DIFF
--- a/content/en/docs/setup/install/overview.md
+++ b/content/en/docs/setup/install/overview.md
@@ -40,6 +40,8 @@ helm upgrade --install \
   --values <values.yaml>
 ```
 
+## Install CLI
+
 Once installation completes, you can interact with the API endpoint using the [OpenAI Python library](https://github.com/openai/openai-python), running our CLI, or directly hitting the endpoint. To download the CLI, run:
 
 {{< include "../../../includes/cli-install.md" >}}


### PR DESCRIPTION
Still a bit hidden, but wanted to have a separate link that we can refer from other location.