### PR TITLE
Revert "chore(deps-dev): bump hugo-extended from 0.145.0 to 0.146.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.14",
     "cross-env": "^7.0.3",
-    "hugo-extended": "0.146.2",
+    "hugo-extended": "0.145.0",
     "postcss-cli": "^11.0.0"
   },
   "private": true,


### PR DESCRIPTION
This reverts commit 73cf5ed3f5a415541538d696cd47c8daddbb984f.